### PR TITLE
Fixed issue (1)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,5 +10,5 @@ door_open_time = 3000
 [hardware]
 n_floors = 4
 driver_address = "host.docker.internal"
-driver_port = 15657
+driver_port = 15658
 hw_thread_sleep_time = 10

--- a/src/elevator/fsm.rs
+++ b/src/elevator/fsm.rs
@@ -185,6 +185,10 @@ impl ElevatorFSM {
                 default(Duration::from_millis(100)) => {
                     match self.state.behaviour {
                         Idle => {
+                            if self.complete_orders() {
+                                self.open_door();
+                            }
+
                             self.state.direction = self.choose_direction();
                             if self.state.direction != Stop {
                                 self.state.behaviour = Moving;


### PR DESCRIPTION
In the idle state of fsm. It will now also check if there are any orders on the floor it's already on. It's tested and works fine with two elevators.

However, the fix felt a bit to easy: So check if its a "too easy" fix.